### PR TITLE
Add basic-test02 example

### DIFF
--- a/basic-test02/README.md
+++ b/basic-test02/README.md
@@ -1,0 +1,5 @@
+This source code was developed by referring to the github repository at the link below.
+<br>
+  -> https://github.com/sartura/ebpf-hello-world
+
+This directory solves an existing TODO in `basic-test01`, which allows a single header file to be created even if multiple eBPF codes exist.

--- a/basic-test02/build.sh
+++ b/basic-test02/build.sh
@@ -1,0 +1,15 @@
+# Create BTF(BPF Type Format) File for Current Kernel
+bpftool btf dump file /sys/kernel/btf/vmlinux format c > ./src/bpf/vmlinux.h
+
+# Build eBPF Code for Tracing
+mkdir build > /dev/null 2>&1
+
+clang -g -O2 -target bpf -D__TARGET_ARCH_x86_64 -I ./src/bpf -c ./src/bpf/syscall_enter.c -o ./build/syscall_enter.o
+clang -g -O2 -target bpf -D__TARGET_ARCH_x86_64 -I ./src/bpf -c ./src/bpf/syscall_exit.c -o ./build/syscall_exit.o
+
+bpftool gen object ./build/monitor.bpf.o ./build/syscall_enter.o ./build/syscall_exit.o
+bpftool gen skeleton ./build/monitor.bpf.o name bpf_monitor > ./src/bpf_monitor.h
+
+# Build Test Code in User-Level
+clang -g -O2 -Wall -I ./src/ -c ./src/test_main.c -o ./build/test_main.o
+clang -Wall -O2 -g ./build/test_main.o ../libbpf_build/libbpf.a -lelf -lz -o test_main

--- a/basic-test02/clean.sh
+++ b/basic-test02/clean.sh
@@ -1,0 +1,4 @@
+rm -rf ./build
+rm -rf ./test_main
+rm -rf ./src/bpf_monitor.h
+rm -rf ./src/bpf/vmlinux.h

--- a/basic-test02/src/bpf/syscall_enter.c
+++ b/basic-test02/src/bpf/syscall_enter.c
@@ -1,0 +1,12 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+SEC("tracepoint/syscalls/sys_enter_execve")
+int tracepoint__syscalls__sys_enter_execve(struct trace_event_raw_sys_enter *ctx)
+{
+	bpf_printk("[Info] execve() syscall Enter!\n");
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";
+

--- a/basic-test02/src/bpf/syscall_exit.c
+++ b/basic-test02/src/bpf/syscall_exit.c
@@ -1,0 +1,11 @@
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+
+SEC("tracepoint/syscalls/sys_exit_execve")
+int tracepoint__syscalls__sys_exit_execve(struct trace_event_raw_sys_enter *ctx)
+{
+        bpf_printk("[Info] execve() syscall Exit!\n");
+        return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/basic-test02/src/test_main.c
+++ b/basic-test02/src/test_main.c
@@ -1,0 +1,75 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/resource.h>
+
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+
+/* This header file are automatically generated */
+#include "bpf_monitor.h"
+
+void read_trace_pipe(void)
+{
+	int trace_fd;
+
+	trace_fd = open("/sys/kernel/debug/tracing/trace_pipe", O_RDONLY, 0);
+	if (trace_fd < 0)
+		return;
+
+	while (1) {
+		static char buf[4096];
+		ssize_t sz;
+
+		sz = read(trace_fd, buf, sizeof(buf) - 1);
+		if (sz > 0) {
+			buf[sz] = 0;
+			puts(buf);
+		}
+	}
+}
+
+int main(void)
+{
+	/* These structures are automatically generated */
+	struct bpf_monitor *obj;
+
+	int err = 0;
+
+	struct rlimit rlim = {
+		.rlim_cur = 512UL << 20,
+		.rlim_max = 512UL << 20,
+	};
+
+	err = setrlimit(RLIMIT_MEMLOCK, &rlim);
+	if (err) {
+		fprintf(stderr, "failed to change rlimit\n");
+		return 1;
+	}
+
+
+	obj = bpf_monitor__open();
+	if (!obj) {
+		fprintf(stderr, "failed to open and/or load BPF object\n");
+		return 1;
+	}
+
+	err = bpf_monitor__load(obj);
+	if (err) {
+		fprintf(stderr, "failed to load BPF object %d\n", err);
+		goto cleanup;
+	}
+
+	err = bpf_monitor__attach(obj);
+	if (err) {
+		fprintf(stderr, "failed to attach BPF programs\n");
+		goto cleanup;
+	}
+
+	read_trace_pipe();
+
+cleanup:
+	bpf_monitor__destroy(obj);
+	return err != 0;
+}


### PR DESCRIPTION
## 작업 내용
1. `basic-test01`에서는 eBPF 코드가 여러개인 경우 각자의 헤더파일을 생성하였지만, 해당 작업은 하나의 헤더파일만 생성하도록 해결함